### PR TITLE
enforce required resource metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Development
 
 - Enforce required resource metadata (`properties/resources/items/required`) in dataset schema.
+- Prepare error message for missing/non-authorized group to be better translatable.
 
 ## [0.3.12](https://github.com/berlinonline/ckanext-berlin_dataset_schema/releases/tag/0.3.12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Development
 
+- Enforce required resource metadata (`properties/resources/items/required`) in dataset schema.
+
 ## [0.3.12](https://github.com/berlinonline/ckanext-berlin_dataset_schema/releases/tag/0.3.12)
 
 _(2025-12-18)_

--- a/ckanext/berlin_dataset_schema/plugin.py
+++ b/ckanext/berlin_dataset_schema/plugin.py
@@ -407,7 +407,7 @@ class Berlin_Dataset_SchemaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatase
                 try:
                     validator.is_group_name_valid(group_name, context)
                 except df.Invalid as e:
-                    _errors['groups'] = _errors.get('groups', []) + [_(f'Group \'{group_name}\' does not exist or cannot be edited by user \'{context["user"]}\'.')]
+                    _errors['groups'] = _errors.get('groups', []) + [str(e.error)]
 
         (data_dict, errors) = toolkit.navl_validate(data_dict, schema, context)
         if action in [ 'package_create', 'package_update' ]:

--- a/ckanext/berlin_dataset_schema/plugin.py
+++ b/ckanext/berlin_dataset_schema/plugin.py
@@ -151,6 +151,14 @@ class Berlin_Dataset_SchemaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatase
                         schema[attribute] = [ required_validator ] + validator_chain
                     else:
                         schema[attribute][0] = required_validator
+
+        resource_schema = schema['resources']
+        for attribute in self.json_schema.resource_schema()['required']:
+            resource_schema[attribute] = [
+                toolkit.get_validator('not_empty'),
+                toolkit.get_validator('unicode_safe')
+            ]
+
         return schema
 
     def _modify_package_schema(self, schema):

--- a/ckanext/berlin_dataset_schema/schema.py
+++ b/ckanext/berlin_dataset_schema/schema.py
@@ -38,14 +38,20 @@ class Schema(plugins.SingletonPlugin):
         except AttributeError:
             raise SchemaError("JSON schema not loaded yet")
 
-    def required(self, attribute):
+    def required(self, attribute: str):
         """
         Helper function to check if a given dataset attribute is required.
         """
-        _required = self.schema().get('required')
-        if _required:
-            return attribute in _required
-        raise SchemaError("JSON Schema does not contain 'required' attribute.")
+        schema = self.schema()
+        haystack = 'schema'
+        if attribute.startswith('resources/'):
+            schema = self.resource_schema()
+            attribute = attribute.split('resources/')[-1]
+            haystack = 'schema/properties/resources/items'
+        required = schema.get('required')
+        if required:
+            return attribute in required
+        raise SchemaError(f"{haystack} does not contain 'required' attribute.")
 
     def contains(self, attribute):
         """
@@ -94,6 +100,19 @@ class Schema(plugins.SingletonPlugin):
             else:
                 raise SchemaError(f"The attribute '{attribute}' does not exist.")
         raise SchemaError("JSON Schema does not contain 'properties' attribute.")
+
+    def resource_schema(self) -> dict:
+        """
+        Convenience function for accessing ['properties']['resources']['items']
+        """
+        properties = self.schema().get('properties')
+        if properties:
+            resources = properties.get('resources')
+            if resources:
+                items = resources.get('items')
+                if items:
+                    return items
+        raise SchemaError("JSON Schema does not contain ['properties']['resources']['items'] path.")
 
 class SchemaError(Exception):
     """

--- a/ckanext/berlin_dataset_schema/tests/test_schema.py
+++ b/ckanext/berlin_dataset_schema/tests/test_schema.py
@@ -72,6 +72,23 @@ class TestCompleteSchema(object):
         with pytest.raises(schema.SchemaError):
             schema.Schema().enum_for_attribute('foo_bar')
 
+    @pytest.mark.parametrize("data", [
+        {
+            'attribute': 'resources/url',
+            'expected': True
+        },
+        {
+            'attribute': 'resources/description',
+            'expected': False
+        },
+        {
+            'attribute': 'resources/boingo',
+            'expected': False
+        },
+    ])
+    def test_required_parses_resources_path(self, berlin_od_schema, data):
+        assert schema.Schema().required(data['attribute']) == data['expected']
+
 class TestEmptySchema(object):
 
     def test_empty_schema_raises_schema_error_on_enum_for_attribute(self, empty_schema):

--- a/ckanext/berlin_dataset_schema/validation.py
+++ b/ckanext/berlin_dataset_schema/validation.py
@@ -191,7 +191,13 @@ class Validator(object):
         if name in group_names:
             return name
         else:
-            raise df.Invalid(_(f'Group \'{name}\' does not exist or cannot be edited by user \'{context["user"]}\'.'))
+            error_message = _(
+                "Group '%(groupname)s' does not exist or cannot be edited by '%(username)s'."
+            ) % {
+                "groupname": name,
+                "username": context["user"],
+            }
+            raise df.Invalid(error_message)
 
     def is_booleanish(self, value: bool) -> bool:
         """


### PR DESCRIPTION
This PR extends the validation of required metadata fields to the resources schema. Currently, `url` and `format` are required, so now we won't get resources without URLs or format metadata anymore.